### PR TITLE
Update life.tcl

### DIFF
--- a/life.tcl
+++ b/life.tcl
@@ -3,55 +3,60 @@
 set n 40; set m 80
 set g 100
 
-proc display {} {
-   global n m b
+proc display {b} {
+   global n m
    for {set i 0} {$i < $n} {incr i} {
       for {set j 0} {$j < $m} {incr j} {
-         if {$b($i,$j)} {puts -nonewline {*}} else {puts -nonewline { }}
+         if {[lindex $b $i $j]} {puts -nonewline {*}} else {puts -nonewline { }}
       }
       puts {}
    }
 }
 
 proc main {} {
-   global n m b g
+   global n m g
 
-   for {set i 0} {$i < $n} {incr i} {for {set j 0} {$j < $m} {incr j} {set b($i,$j) 0}}
+   # we want C-array like behaviour, not associative hashmaps   
+   set b [lrepeat $n [lrepeat $m 0]]
+
    # initialization
-   set b(19,41) 1
-   set b(20,40) 1
-   set b(21,40) 1
-   set b(22,40) 1
-   set b(22,41) 1
-   set b(22,42) 1
-   set b(22,43) 1
-   set b(19,44) 1
-   # end of initialization
-   puts "Before:"; display
+   lset b 19 41 1
+   lset b 20 40 1
+   lset b 21 40 1
+   lset b 22 40 1
+   lset b 22 41 1
+   lset b 22 42 1
+   lset b 22 43 1
+   lset b 19 44 1
 
-   set nm1 [expr $n - 1]
-   set mm1 [expr $m - 1]
+   # end of initialization
+   puts "Before:"; display $b
+
+   set nm1 [expr {$n - 1}]
+   set mm1 [expr {$m - 1}]
    for {set k 0} {$k < $g} {incr k} {
+      set nextb [lrepeat $n [lrepeat $m 0]]
       for {set i 0} {$i < $n} {incr i} {
-         set up   [expr $i != 0 ? $i - 1 : $nm1]
-         set down [expr $i != $nm1 ? $i + 1 : 0]
+         set up   [expr {$i != 0 ? $i - 1 : $nm1}]
+         set down [expr {$i != $nm1 ? $i + 1 : 0}]
          for {set j 0} {$j < $m} {incr j} {
-            set left  [expr $j != 0 ? $j - 1 : $mm1]
-            set right [expr $j != $mm1 ? $j + 1 : 0]
-            set count [expr       \
-               $b($up,$left)    + \
-               $b($up,$j)       + \
-               $b($up,$right)   + \
-               $b($i,$right)    + \
-               $b($down,$right) + \
-               $b($down,$j)     + \
-               $b($down,$left)  + \
-               $b($i,$left)]
-            set nextb($i,$j) [expr $count == 2 && $b($i,$j) || $count == 3]
+            set left  [expr {$j != 0 ? $j - 1 : $mm1}]
+            set right [expr {$j != $mm1 ? $j + 1 : 0}]
+            set count [expr {     \
+               [lindex $b $up $left]    + \
+               [lindex $b $up $j]       + \
+               [lindex $b $up $right]   + \
+               [lindex $b $i $right]    + \
+               [lindex $b $down $right] + \
+               [lindex $b $down $j]     + \
+               [lindex $b $down $left]  + \
+               [lindex $b $i $left]}]
+            set nextval [expr {$count == 2 && [lindex $b $i $j] == 1 || $count == 3}]
+            lset nextb $i $j $nextval 
          }
       }
-      for {set i 0} {$i < $n} {incr i} {for {set j 0} {$j < $m} {incr j} {set b($i,$j) $nextb($i,$j)}}
+      set b $nextb
    }
-   puts "After $g generations:"; display
+   puts "After $g generations:"; display $b
 }
 main


### PR DESCRIPTION
- Use Tcl equivalent of the real C-style arrays (lists), not the associative hashmaps/variable collections listed as array.
- Brace all expressions (Tcl performance 101), otherwise the performance is often a factor of 1000 worse.
- Avoid the global variable b to speed up referencing it in a proc context.

Could probably be made even faster by replacing the inner for loops with a single lmap (https://www.tcl.tk/man/tcl/TclCmd/lmap.htm) call.

I does not help to use a Tcl released in 2009 either (Tcl 8.5.7...), 8.6.0 is from 2013.